### PR TITLE
AWS Lambda requires libssl.so.10

### DIFF
--- a/srp/_ctsrp.py
+++ b/srp/_ctsrp.py
@@ -143,7 +143,7 @@ elif 'win' in platform:
         except:
             pass
 else:
-    dlls.append( ctypes.cdll.LoadLibrary('libssl.so') )
+    dlls.append( ctypes.cdll.LoadLibrary('libssl.so.10') )
 
 
 class BIGNUM_Struct (ctypes.Structure):


### PR DESCRIPTION
AWS Lambda doesn't have libssl.so in /usr/lib64, so I modified just one line. 