### PR TITLE
Fall back to _pysrp when libssl cannot be imported

### DIFF
--- a/srp/__init__.py
+++ b/srp/__init__.py
@@ -4,7 +4,7 @@ _mod     = None
 try:
     import srp._ctsrp
     _mod = srp._ctsrp
-except ImportError:
+except (ImportError, OSError):
     pass
 
 if not _mod:


### PR DESCRIPTION
Add OSError to the list of exceptions swallowed when importing _ctsrp,
so that `srp` will not fail to import when libssl is not found.