### PR TITLE
Fixes #28 calculate_x() throws TypeError exception

### DIFF
--- a/srp/_ctsrp.py
+++ b/srp/_ctsrp.py
@@ -281,7 +281,7 @@ def update_hash( ctx, n ):
 def calculate_M( hash_class, N, g, I, s, A, B, K ):
     h = hash_class()
     h.update( HNxorg( hash_class, N, g ) )
-    h.update( hash_class(I).digest() )
+    h.update( hash_class(I.encode()).digest() )
     update_hash( h, s )
     update_hash( h, A )
     update_hash( h, B )

--- a/srp/_ctsrp.py
+++ b/srp/_ctsrp.py
@@ -268,7 +268,7 @@ def H_bn_str( hash_class, dest, n, s ):
 
 
 def calculate_x( hash_class, dest, salt, username, password ):
-    up = hash_class(username + six.b(':') + password).digest()
+    up = hash_class(username.encode() + six.b(':') + password.encode()).digest()
     H_bn_str( hash_class, dest, salt, up )
 
 


### PR DESCRIPTION
Converted both username and password arguments to byte arrays upon contatenating them to the string sent to the digest() method of the hash_class.