### PR TITLE
check for OpenSLL 1.0

### DIFF
--- a/srp/_ctsrp.py
+++ b/srp/_ctsrp.py
@@ -143,8 +143,13 @@ elif 'win' in platform:
         except:
             pass
 else:
-    dlls.append( ctypes.cdll.LoadLibrary('libssl.so') )
-
+    try:
+        dlls.append( ctypes.cdll.LoadLibrary('libssl.so.10') )
+    except OSError:
+        try:
+            dlls.append( ctypes.cdll.LoadLibrary('libssl.so.1.0.0') )
+        except OSError:
+            dlls.append( ctypes.cdll.LoadLibrary('libssl.so') )
 
 class BIGNUM_Struct (ctypes.Structure):
     _fields_ = [ ("d",     ctypes.c_void_p),


### PR DESCRIPTION
Loading the functions fails with OpenSSL 1.1. To ensure OpenSSL 1.0 is
loaded we try to load "libssl.so.10", "libssl.so.1.1.0" and "libssl.so".
"libssl.so.10" is the name in Debian, Ubuntu, ZentOS, ...
"libssl.so.1.1.0" is the name in arch, ...
"libssl.so" will now mostly refer to OpenSSL 1.1, but it could be
OpenSSL 1.0, so it is added as a fallback.

We could add a check to libssl.so by looking if the method SSLeay() exists, but I thought it unnecessary - the load function will fail if OpenSSL 1.1 is used anyhow.

This is a more generic approach than #23 