### PR TITLE
g is padded

### DIFF
--- a/srp/_ctsrp.py
+++ b/srp/_ctsrp.py
@@ -322,8 +322,10 @@ def HNxorg( hash_class, N, g ):
     BN_bn2bin(N, bN)
     BN_bn2bin(g, bg)
 
+    padding = len(bN) - len(bg)
+
     hN = hash_class( bN.raw ).digest()
-    hg = hash_class( bg.raw ).digest()
+    hg = hash_class( b''.join([ b'\0'*padding, bg.raw ]) ).digest()
 
     return six.b( ''.join( chr( six.indexbytes(hN, i) ^ six.indexbytes(hg, i) ) for i in range(0,len(hN)) ) )
 

--- a/srp/_ctsrp.py
+++ b/srp/_ctsrp.py
@@ -322,7 +322,7 @@ def HNxorg( hash_class, N, g ):
     BN_bn2bin(N, bN)
     BN_bn2bin(g, bg)
 
-    padding = len(bN) - len(bg)
+    padding = len(bN) - len(bg) if _rfc5054_compat else 0
 
     hN = hash_class( bN.raw ).digest()
     hg = hash_class( b''.join([ b'\0'*padding, bg.raw ]) ).digest()

--- a/srp/_pysrp.py
+++ b/srp/_pysrp.py
@@ -197,7 +197,7 @@ def HNxorg( hash_class, N, g ):
     bin_N = long_to_bytes(N)
     bin_g = long_to_bytes(g)
 
-    padding = len(bin_N) - len(bin_g)
+    padding = len(bin_N) - len(bin_g) if _rfc5054_compat else 0
 
     hN = hash_class( bin_N ).digest()
     hg = hash_class( b''.join( [b'\0'*padding, bin_g] ) ).digest()

--- a/srp/_pysrp.py
+++ b/srp/_pysrp.py
@@ -194,8 +194,13 @@ def H( hash_class, *args, **kwargs ):
 #k = H(N,g)
 
 def HNxorg( hash_class, N, g ):
-    hN = hash_class( long_to_bytes(N) ).digest()
-    hg = hash_class( long_to_bytes(g) ).digest()
+    bin_N = long_to_bytes(N)
+    bin_g = long_to_bytes(g)
+
+    padding = len(bin_N) - len(bin_g)
+
+    hN = hash_class( bin_N ).digest()
+    hg = hash_class( b''.join( [b'\0'*padding, bin_g] ) ).digest()
 
     return six.b( ''.join( chr( six.indexbytes(hN, i) ^ six.indexbytes(hg, i) ) for i in range(0,len(hN)) ) )
 


### PR DESCRIPTION
Everywhere in [rfc5054](http://www.ietf.org/rfc/rfc5054.txt) the generator (`g`) is padded to be the same size of prime (`N`), but it wasn't in your `HNxorg` function.
`g` is byte array and should not be treated like number.
I checked it and this changed new function works exactly like Apple's SRP.