### PR TITLE
Adds no_username_in_x for compatibility with Apple's SRP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ please refer to the `srp module documentation`_.
 '''
 
 setup(name             = 'srp',
-      version          = '1.0.13',
+      version          = '1.0.15',
       description      = 'Secure Remote Password',
       author           = 'Tom Cocagne',
       author_email     = 'tom.cocagne@gmail.com',

--- a/srp/__init__.py
+++ b/srp/__init__.py
@@ -27,4 +27,5 @@ NG_4096   = _mod.NG_4096
 NG_8192   = _mod.NG_8192
 NG_CUSTOM = _mod.NG_CUSTOM
 
-rfc5054_enable = _mod.rfc5054_enable
+rfc5054_enable   = _mod.rfc5054_enable
+no_username_in_x = _mod.no_username_in_x

--- a/srp/_ctsrp.py
+++ b/srp/_ctsrp.py
@@ -291,7 +291,7 @@ def calculate_x( hash_class, dest, salt, username, password ):
     username = username.encode() if hasattr(username, 'encode') else username
     password = password.encode() if hasattr(password, 'encode') else password
     if _no_username_in_x:
-        username = ''
+        username = six.b('')
     up = hash_class(username + six.b(':') + password).digest()
     H_bn_str( hash_class, dest, salt, up )
 

--- a/srp/_ctsrp.py
+++ b/srp/_ctsrp.py
@@ -24,10 +24,15 @@ import six
 
 
 _rfc5054_compat = False
+_no_username_in_x = False
 
 def rfc5054_enable(enable=True):
     global _rfc5054_compat
     _rfc5054_compat = enable
+
+def no_username_in_x(enable=True):
+    global _no_username_in_x
+    _no_username_in_x = enable
 
 
 SHA1   = 0
@@ -285,6 +290,8 @@ def H_bn_str( hash_class, dest, n, s ):
 def calculate_x( hash_class, dest, salt, username, password ):
     username = username.encode() if hasattr(username, 'encode') else username
     password = password.encode() if hasattr(password, 'encode') else password
+    if _no_username_in_x:
+        username = ''
     up = hash_class(username + six.b(':') + password).digest()
     H_bn_str( hash_class, dest, salt, up )
 

--- a/srp/_pysrp.py
+++ b/srp/_pysrp.py
@@ -20,10 +20,15 @@ import six
 
 
 _rfc5054_compat = False
+_no_username_in_x = False
 
 def rfc5054_enable(enable=True):
     global _rfc5054_compat
     _rfc5054_compat = enable
+
+def no_username_in_x(enable=True):
+    global _no_username_in_x
+    _no_username_in_x = enable
 
 
 SHA1   = 0
@@ -209,6 +214,8 @@ def HNxorg( hash_class, N, g ):
 def gen_x( hash_class, salt, username, password ):
     username = username.encode() if hasattr(username, 'encode') else username
     password = password.encode() if hasattr(password, 'encode') else password
+    if _no_username_in_x:
+        username = ''
     return H( hash_class, salt, H( hash_class, username + six.b(':') + password ) )
 
 

--- a/srp/_pysrp.py
+++ b/srp/_pysrp.py
@@ -215,7 +215,7 @@ def gen_x( hash_class, salt, username, password ):
     username = username.encode() if hasattr(username, 'encode') else username
     password = password.encode() if hasattr(password, 'encode') else password
     if _no_username_in_x:
-        username = ''
+        username = six.b('')
     return H( hash_class, salt, H( hash_class, username + six.b(':') + password ) )
 
 


### PR DESCRIPTION
I know this repo is old and has not been updated in years, but I could finally find the difference between this and Apple's SRP implementation in CoreCrypto.
Your library is almost 100% compatible with that, except this important option to omit username when calculating x.
This won't break anything. It would be great if you could merge it and update pypi.
Thanks