### PR TITLE
Don't try to load BN_init and BN_CTX_init from OpenSSL

### DIFF
--- a/srp/_ctsrp.py
+++ b/srp/_ctsrp.py
@@ -196,11 +196,9 @@ def load_func( name, args, returns = ctypes.c_int):
 
 load_func( 'BN_new',   [],         BIGNUM )
 load_func( 'BN_free',  [ BIGNUM ], None )
-load_func( 'BN_init',  [ BIGNUM ], None )
 load_func( 'BN_clear', [ BIGNUM ], None )
 
 load_func( 'BN_CTX_new',  []        , BN_CTX )
-load_func( 'BN_CTX_init', [ BN_CTX ], None   )
 load_func( 'BN_CTX_free', [ BN_CTX ], None   )
 
 load_func( 'BN_cmp',      [ BIGNUM, BIGNUM ], ctypes.c_int )


### PR DESCRIPTION
Both functions were removed in OpenSSL 1.1.0, and aren't being used anyway.