### PR TITLE
Use libssl.so.1.1

### DIFF
--- a/srp/_ctsrp.py
+++ b/srp/_ctsrp.py
@@ -155,12 +155,9 @@ elif 'win' in platform:
             pass
 else:
     try:
-        dlls.append( ctypes.cdll.LoadLibrary('libssl.so.10') )
+        dlls.append( ctypes.cdll.LoadLibrary('libssl.so.1.1.0') )
     except OSError:
-        try:
-            dlls.append( ctypes.cdll.LoadLibrary('libssl.so.1.0.0') )
-        except OSError:
-            dlls.append( ctypes.cdll.LoadLibrary('libssl.so') )
+        dlls.append( ctypes.cdll.LoadLibrary('libssl.so') )
 
 class BIGNUM_Struct (ctypes.Structure):
     _fields_ = [ ("d",     ctypes.c_void_p),


### PR DESCRIPTION
Building with libssl.so.1.0 fails since adding `BN_set_flags` import. (Tested on arch with libssl 1.0.2)
To ensure libssl 1.1 is used update the imports.

`libssl.sl.10` has been removed as Ubuntu etc now seem to use the `libssl.so.1.1` naming convention. [1]

[1] https://packages.ubuntu.com/bionic/amd64/libssl1.1/filelist